### PR TITLE
Update static class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.0.2
 * Change the pubspec to increase the score and improve the example folder
 * Now this package is full compatible with Ios, Android, Web, Macos
+* Update Readme
+* Tanks to @brasizza
 
 ## 0.0.1
 * TODO: Describe initial release.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'home/home_page.dart';
 
 void main() {
-  AsyncState.onInitAsyncState(
+  AsyncState.setLoaderPersonalized(
     defaultDialogWidget: const MyLoading(),
 
     /// Here you can customize your default loading that will show every transaction

--- a/lib/class/async_class.dart
+++ b/lib/class/async_class.dart
@@ -1,13 +1,18 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+
 import '/exceptions/async_state_exception.dart';
 import '/observers/async_navigator_observer.dart';
 import 'package:flutter/material.dart';
 
 /// Static class that will start the instance
-late final AsyncState asyncState;
+final AsyncState asyncState = AsyncState();
 
 @protected
 class AsyncState<T> {
-  final Widget? _defaultDialog;
+  Widget? defaultDialog;
   BuildContext? context;
   static final _observer = AsyncNavigatorObserver();
 
@@ -15,23 +20,13 @@ class AsyncState<T> {
 
   //Static Init
   static AsyncNavigatorObserver get observer => _observer;
-  static onInitAsyncState({
+  static setLoaderPersonalized({
     Widget? defaultDialogWidget,
   }) =>
-      asyncState = AsyncState(
-        defaultDialogWidget: defaultDialogWidget ??
-            const SizedBox(
-              width: 50,
-              height: 50,
-              child: Center(
-                child: CircularProgressIndicator(),
-              ),
-            ),
-      );
+      asyncState.defaultDialog = defaultDialogWidget;
+
   //Constructor
-  AsyncState({
-    required Widget defaultDialogWidget,
-  }) : _defaultDialog = defaultDialogWidget;
+  AsyncState();
 
   Future<T> callAsyncLoader(Future<T> futureFunction,
       {Widget? customLoader}) async {
@@ -61,7 +56,19 @@ class AsyncState<T> {
         context: context!,
         useRootNavigator: false,
         builder: (_) => AlertDialog(
-          content: customLoader ?? _defaultDialog,
+          content: customLoader ??
+              defaultDialog ??
+              SizedBox(
+                width: 50,
+                height: 50,
+                child: Center(
+                  child: kIsWeb
+                      ? const CircularProgressIndicator()
+                      : Platform.isIOS
+                          ? CupertinoActionSheet()
+                          : const CircularProgressIndicator(),
+                ),
+              ),
         ),
       ),
       futureFunction.whenComplete(() {

--- a/lib/class/async_class.dart
+++ b/lib/class/async_class.dart
@@ -56,7 +56,8 @@ class AsyncState<T> {
         context: context!,
         useRootNavigator: false,
         builder: (_) => AlertDialog(
-          content: customLoader ??
+            content: WillPopScope(
+          child: customLoader ??
               defaultDialog ??
               SizedBox(
                 width: 50,
@@ -69,7 +70,8 @@ class AsyncState<T> {
                           : const CircularProgressIndicator(),
                 ),
               ),
-        ),
+          onWillPop: () async => false,
+        )),
       ),
       futureFunction.whenComplete(() {
         Navigator.of(context!).pop();


### PR DESCRIPTION
Casse static ja iniciada.
Agora contem (setLoaderPersonalized) que pode chamado em main.dart ou bindings.
Se não for setado nenhum loaderPersonalized utiliza o padrão do SO (iOS ou Android).

Para usar o package apenas necessario o NavigatorObserver agora.