### PR TITLE
Change CupertinoActionSheet to CupertinoActivityIndicator

### DIFF
--- a/lib/class/async_class.dart
+++ b/lib/class/async_class.dart
@@ -66,7 +66,7 @@ class AsyncState<T> {
                   child: kIsWeb
                       ? const CircularProgressIndicator()
                       : Platform.isIOS
-                          ? CupertinoActionSheet()
+                          ? const CupertinoActivityIndicator()
                           : const CircularProgressIndicator(),
                 ),
               ),


### PR DESCRIPTION
Change the CupertinoActionSheet to CupertinoActivityIndicator, because the CircularProgress  from android is CupertinoActivityIndicator in IOS!